### PR TITLE
xml_save_load

### DIFF
--- a/MoveRobot/blockly_func.js
+++ b/MoveRobot/blockly_func.js
@@ -1,103 +1,156 @@
-﻿	var workspacePlayground = Blockly.inject(
-  			'blocklyDiv',
-  		{
-    		toolbox: document.getElementById('toolbox'),
-    		grid: {
-      			spacing: 18,
-      			length: 3,
-      			colour: '#ccc',
-      			snap: true,
-    		},
-    		trashcan: true,
-    		zoom: {
-      			controls: true,
-      			wheel: true,
-      			startScale: 1.0,
-      			maxScale: 3,
-      			minScale: 0.3,
-      			scaleSpeed: 1.2,
-    		},
-  		},);
+﻿var workspacePlayground = Blockly.inject(
+    'blocklyDiv',
+    {
+    	toolbox: document.getElementById('toolbox'),
+    	grid: {
+      	    spacing: 18,
+      	    length: 3,
+      	    colour: '#ccc',
+      	    snap: true,
+    	},
+    	trashcan: true,
+    	zoom: {
+      	    controls: true,
+      	    wheel: true,
+      	    startScale: 1.0,
+      	    maxScale: 3,
+      	    minScale: 0.3,
+      	    scaleSpeed: 1.2,
+    	},
+    },);
 
-		function showCode() {
-  			Blockly.JavaScript.INFINITE_LOOP_TRAP = null;
-  			const pre = document.getElementById('code');
+function showCode() {
+    Blockly.JavaScript.INFINITE_LOOP_TRAP = null;
+    const pre = document.getElementById('code');
 
-  			var code = trans();
-		
-  			pre.value = code;
-		}
+    var code = trans();
+    
+    pre.value = code;
 
-		function saveCode(){
-			var code = trans();
-			//code = code.replace( /<br>/g , '\n' ) ;
-			download(new Blob([code]), 'Blockly_code.txt');
-		}
+    //xml
+    var xmlDom = Blockly.Xml.workspaceToDom(workspacePlayground);
+    var xmlText = Blockly.Xml.domToPrettyText(xmlDom);
+    document.getElementById('XmlText').value = xmlText ;
+}
 
-	function copyCode(){
-		var code = trans();
-		//code = code.replace( /<br>/g , '\n' ) ;
-		if(execCopy(code)){
-    		alert('コピーできました');
-  		}else {
-    		alert('このブラウザでは対応していません');
-  		}
-	}
-	
-	function insertStr(str, index, insert) {
-    	return str.slice(0, index) + insert + str.slice(index, str.length);
-	}
-	
-	function download(blob, filename) {
-  		const objectURL = window.URL.createObjectURL(blob),
-      	a = document.createElement('a'),
-      	e = document.createEvent('MouseEvent');
+function saveCode(){
+    var code = trans();
+    //code = code.replace( /<br>/g , '\n' ) ;
+    download(new Blob([code]), 'Blockly_code.txt');
+}
 
-  		//a要素のdownload属性にファイル名を設定
-  		a.download = filename;
-  		a.href = objectURL;
+function copyCode(){
+    var code = trans();
+    //code = code.replace( /<br>/g , '\n' ) ;
+    if(execCopy(code)){
+    	alert('コピーできました');
+    }else {
+    	alert('このブラウザでは対応していません');
+    }
+}
 
-  		//clickイベントを着火
-  		e.initEvent("click", true, true, window, 1, 0, 0, 0, 0, false, false, false, false, 0, null);
-  		a.dispatchEvent(e);
-	}
-	
-	function execCopy(string){
-  		var temp = document.createElement('div');
+function insertStr(str, index, insert) {
+    return str.slice(0, index) + insert + str.slice(index, str.length);
+}
 
-  		temp.appendChild(document.createElement('pre')).textContent = string;
+function download(blob, filename) {
+    const objectURL = window.URL.createObjectURL(blob),
+      	  a = document.createElement('a'),
+      	  e = document.createEvent('MouseEvent');
 
-  		var s = temp.style;
-  		s.position = 'fixed';
-  		s.left = '-100%';
+    //a要素のdownload属性にファイル名を設定
+    a.download = filename;
+    a.href = objectURL;
 
-  		document.body.appendChild(temp);
-  		document.getSelection().selectAllChildren(temp);
+    //clickイベントを着火
+    e.initEvent("click", true, true, window, 1, 0, 0, 0, 0, false, false, false, false, 0, null);
+    a.dispatchEvent(e);
+}
 
-  		var result = document.execCommand('copy');
+function execCopy(string){
+    var temp = document.createElement('div');
 
-  		document.body.removeChild(temp);
-  		// true なら実行できている falseなら失敗か対応していないか
-  		return result;
-	}
+    temp.appendChild(document.createElement('pre')).textContent = string;
 
-	function trans(){
-		var code = Blockly.JavaScript.workspaceToCode(workspacePlayground);
-		
-		code = code.replace( /var/g , "int" ) ;
-		code = code.replace( /true/g , "1" ) ;
-		code = code.replace( /false/g , "0" ) ;
-		code = code.replace( /<br>/g , '\n' ) ;
-		
-		var index;
-		while( index = code.indexOf('typeof'),index != -1) {
-			var R = code.indexOf( ")", index );
-			code = code.substr(0, index-3) + code.substr(R+1);
-			var P = code.indexOf( "+", index-3 );
-			code = insertStr(code, P+1, '=');
-		}
-		return code;
-	}
-	document.getElementById('showCode').addEventListener('click', showCode, false);
-	document.getElementById('saveCode').addEventListener('click', saveCode, false);
-	document.getElementById('copyCode').addEventListener('click', copyCode, false);
+    var s = temp.style;
+    s.position = 'fixed';
+    s.left = '-100%';
+
+    document.body.appendChild(temp);
+    document.getSelection().selectAllChildren(temp);
+
+    var result = document.execCommand('copy');
+
+    document.body.removeChild(temp);
+    // true なら実行できている falseなら失敗か対応していないか
+    return result;
+}
+
+function trans(){
+    var code = Blockly.JavaScript.workspaceToCode(workspacePlayground);
+    
+    code = code.replace( /var/g , "int" ) ;
+    code = code.replace( /true/g , "1" ) ;
+    code = code.replace( /false/g , "0" ) ;
+    code = code.replace( /<br>/g , '\n' ) ;
+    
+    var index;
+    while( index = code.indexOf('typeof'),index != -1) {
+	var R = code.indexOf( ")", index );
+	code = code.substr(0, index-3) + code.substr(R+1);
+	var P = code.indexOf( "+", index-3 );
+	code = insertStr(code, P+1, '=');
+    }
+    return code;
+}
+
+function saveXml() {
+    var xmlDom = Blockly.Xml.workspaceToDom(workspacePlayground);
+    var xmlText = Blockly.Xml.domToPrettyText(xmlDom);
+    //console.log(xmlText);
+    download(new Blob([xmlText]), 'Blockly_xml.txt');
+}
+
+function loadXml() {
+    xmlText = document.getElementById('XmlText').value;
+     xmlText  =  xmlText .replace( /'\n'/g , "" ) ;
+    
+    try {
+        xmlDom = Blockly.Xml.textToDom(xmlText);
+    } catch (e) {
+	// (エラー処理)
+	alert("XMLエラー");
+    }
+    if (xmlDom) {
+        workspacePlayground.clear();
+        Blockly.Xml.domToWorkspace(xmlDom, workspacePlayground);
+	showCode();
+    }
+}
+
+function startXml() {
+    document.getElementById('XmlText').value = '<xml xmlns="https://developers.google.com/blockly/xml"><block type="start" id="o!$D}]eFeZYgqZQpd]1^" x="63" y="45"/></xml>';
+    loadXml();
+}
+
+var oldXml = "";
+
+function autoXml() {
+    var xmlDom = Blockly.Xml.workspaceToDom(workspacePlayground);
+    var xmlText = Blockly.Xml.domToPrettyText(xmlDom);
+
+    if(oldXml != xmlText){
+	showCode();
+    }
+    oldXml = xmlText;
+}
+
+startXml() ;
+
+setInterval(autoXml, 500);
+
+//document.getElementById('showCode').addEventListener('click', showCode, false);
+document.getElementById('saveCode').addEventListener('click', saveCode, false);
+document.getElementById('copyCode').addEventListener('click', copyCode, false);
+document.getElementById('saveXml').addEventListener('click', saveXml, false);
+document.getElementById('loadXml').addEventListener('click', loadXml, false);

--- a/MoveRobot/index.html
+++ b/MoveRobot/index.html
@@ -38,7 +38,6 @@
       </category>
       
       <category name="くりかえし" colour="120">
-	<block type="start"></block>
 	<block type="controls_repeat_ext"></block>
 	<block type="controls_repeat"></block>
     	<block type="controls_whileUntil"></block>
@@ -72,15 +71,21 @@
       
       <category name="変数" colour="330" custom="VARIABLE">
       </category>
+
+      <category name="スタート" colour="120">
+	<block type="start"></block>
+      </category>
     </xml>
   </head>
 
 
   <body>
 
-    <button id="showCode">へんかん</button>
-    <button id="saveCode">ほぞん</button>
-    <button id="copyCode">コピー</button>
+    <!--<button id="showCode">へんかん</button>-->
+    <button id="saveXml">ブロックのほぞん</button>
+    <button id="loadXml">ブロックのよみこみ</button>
+    <button id="saveCode">コードのほぞん</button>
+    <button id="copyCode">コードのコピー</button>
 
     <button id="mission1"　style="position:absolute">ミッション1</button>
     <button id="mission2"　style="position:absolute">ミッション2</button>
@@ -102,6 +107,12 @@
 
     <div>
       <h2><textarea id="obstacle" class="big"
+		    style="position:absolute; height: 480px; width: 400px; border-radius: 10px; box-shadow: 5px 5px 5px #AAA; border-style: solid ; border-width: 1px;
+			   -webkit-transform: translate(0%, -5%); transform: translate(0%, -5%);"></textarea></h2>
+    </div>
+
+    <div>
+      <h2><textarea id="XmlText" class="big"
 		    style="position:absolute; height: 480px; width: 400px; border-radius: 10px; box-shadow: 5px 5px 5px #AAA; border-style: solid ; border-width: 1px;
 			   -webkit-transform: translate(0%, -5%); transform: translate(0%, -5%);"></textarea></h2>
     </div>
@@ -161,6 +172,15 @@
 	  obstacle.style.height = obstacle_h + "px";
 	  obstacle.style.left = blocklyDiv_w + "px";
 	  obstacle.style.top = (code_h + 60) + "px";
+
+
+	  var XmlText = document.getElementById("XmlText");
+	  var XmlText_w = code_w;
+	  var XmlText_h = gameContainer_h;
+	  XmlText.style.width = XmlText_w + "px";
+	  XmlText.style.height = XmlText_h + "px";
+	  XmlText.style.left = blocklyDiv_w + "px";
+	  XmlText.style.top = (window_H ) + "px";
       }
 
       


### PR DESCRIPTION
ブロックの保存、読み込みに対応
（UIは大幅変更を予定）
保存：
XML形式でブロックをDL
読み込み：
右側上から３つ目のテキストエリアに保存したXMLをペーストした後、読み込みボタンを押す

また、「スタート」ブロックを配置した状態ではじまるように変更。
以前は「へんかん」ボタンを押す必要がったが、自動で変換するように変更